### PR TITLE
setup.py and command line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
     <img src="https://github.com/sonovice/smude/raw/master/images/example_output.jpg" width="49%" style="border:1px solid black" />
 </p>
 
-
-## Quick Start
-Clone this repository and make sure that all dependencies listed in `environment.yml` are installed, e.g. using conda:
+## Installation
+### Using Conda
+Clone this repository and :
 ```bash
 $ git clone https://github.com/sonovice/smude.git
 $ cd smude
@@ -17,6 +17,19 @@ $ conda env create -f environment.yml
 $ conda activate smude
 ```
 
+### Using Python
+Clone this repository and install the package using the setup.py:
+```bash
+$ git clone https://github.com/sonovice/smude.git
+$ cd smude
+$ python3 setup.py install
+```
+
+## Usage
+### Via the command line
+Installing the package adds a command-line interface called `smude`. `smude -h` provides the instructions.
+
+### Using the Library
 See `example.py` for a simple usage example:
 ```python
 from skimage.io import imread, imsave

--- a/README.md
+++ b/README.md
@@ -29,6 +29,23 @@ $ python3 setup.py install
 ### Via the command line
 Installing the package adds a command-line interface called `smude`. `smude -h` provides the instructions.
 
+```bash
+$ smude -h
+usage: smude [-h] [-o OUTFILE] [--no-binarization] [--use-gpu] infile
+
+Dewarp and binarize sheet music images.
+
+positional arguments:
+  infile                Specify the input image
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -o OUTFILE, --outfile OUTFILE
+                        Specify the output image (default: result.png)
+  --no-binarization     Deactivate binarization
+  --use-gpu             use GPU
+```
+
 ### Using the Library
 See `example.py` for a simple usage example:
 ```python

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,18 @@ setup(
     url='https://github.com/sonovice/smude',
     packages=['smude'],
 
+    entry_points={
+        'console_scripts': [
+            'smude = smude:main',
+        ],
+    },
+
+    python_requires='>=3.8.5',
+
     install_requires=[
         'scikit-image>=0.18.1',
         'opencv-contrib-python>=4.5.1.48',
-        'requests>=2.25.1',
+        'requests>=2.24.0',
         'pytorch-lightning>=1.1.2',
         'torchvision>=0.8.2',
     ],

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+from setuptools import setup
+
+setup(
+    name='smude',
+    version='0.1.0',
+    description='Sheet Music Dewarping',
+    author='Simon Waloschek',
+    url='https://github.com/sonovice/smude',
+    packages=['smude'],
+
+    install_requires=[
+        'scikit-image>=0.18.1',
+        'opencv-contrib-python>=4.5.1.48',
+        'requests>=2.25.1',
+        'pytorch-lightning>=1.1.2',
+        'torchvision>=0.8.2',
+    ],
+)

--- a/smude/__init__.py
+++ b/smude/__init__.py
@@ -2,6 +2,7 @@ __author__ = "Simon Waloschek"
 
 import logging
 import os
+import argparse
 
 import cv2 as cv
 import numpy as np
@@ -10,6 +11,7 @@ import torch
 import torch.nn.functional as F
 import torchvision.transforms as transforms
 from skimage.color import gray2rgb
+from skimage.io import imread, imsave
 from tqdm import tqdm
 
 from .binarize import binarize
@@ -181,3 +183,17 @@ class Smude():
             dewarped = np.stack(dewarped, axis=2)
             
         return dewarped
+
+def main():
+    parser = argparse.ArgumentParser(description='Dewarp and binarize sheet music images.')
+    parser.add_argument('infile', help='Specify the input image')
+    parser.add_argument('-o', '--outfile', help='Specify the output image (default: result.png)', default='result.png')
+    parser.add_argument('--no-binarization', help='Deactivate binarization', action='store_false')
+    parser.add_argument('--use-gpu', help='use GPU', action='store_true')
+    args = parser.parse_args()
+
+    smude = Smude(use_gpu=args.use_gpu, binarize_output=args.no_binarization)
+
+    image = imread(args.infile)
+    result = smude.process(image)
+    imsave(args.outfile, result)


### PR DESCRIPTION
This PR adds a setup.py and installs the command line interface `smude`. (Issue #6)

The following parameter are available:
```bash
$ smude -h
usage: smude [-h] [-o OUTFILE] [--no-binarization] [--use-gpu] infile

Dewarp and binarize sheet music images.

positional arguments:
  infile                Specify the input image

optional arguments:
  -h, --help            show this help message and exit
  -o OUTFILE, --outfile OUTFILE
                        Specify the output image (default: result.png)
  --no-binarization     Deactivate binarization
  --use-gpu             use GPU
```

I'm not totally sure about the required packages. It works for me. Can you please check it also?

I tried to add the correct metadata to the setup.py. Can you please check, if it's correct? Maybe it would be also good to update the version number. Currently, it's still 0.1.0.